### PR TITLE
Add basic support split-window-right and split-window-below

### DIFF
--- a/base-keymap.json
+++ b/base-keymap.json
@@ -339,6 +339,14 @@
         "command": "emax_other_window"
     },
     {
+        "keys": ["ctrl+x", "2"],
+        "command": "emax_split_window_right"
+    },
+    {
+        "keys": ["ctrl+x", "3"],
+        "command": "emax_split_window_below"
+    },
+    {
         "keys": ["meta+v"],
         "args": {"forward": false, "by": "pages"},
         "command": "move"

--- a/emax_commands.py
+++ b/emax_commands.py
@@ -764,3 +764,45 @@ class EmaxOtherWindowCommand(WindowCommand):
 
 
 
+class EmaxSplitWindowRightCommand(WindowCommand):
+    """
+    Similar to 'split-window-right', i.e. C-x 2.
+
+    Divide the current window into half inserting a new window on the right.
+    """
+
+    layout_key = 'cols'
+    new_cell_indices = [0, 2]
+
+    def run(self):
+        active = self.window.active_group()
+
+        layout = self.window.get_layout()
+
+        pcnts = layout[self.layout_key]
+
+        pcnts.insert(active + 1,
+                     pcnts[active] + (pcnts[active + 1] - pcnts[active]) * 0.5)
+
+        current_cell = layout['cells'][active]
+
+        next_cell = current_cell[:]
+        for i in self.new_cell_indices:
+            next_cell[i] += 1
+
+        layout['cells'].insert(active + 1, next_cell)
+
+        self.window.set_layout(layout)
+
+
+
+class EmaxSplitWindowBelowCommand(EmaxSplitWindowRightCommand):
+    """
+    Similar to 'split-window-below', i.e. C-x 3.
+
+    Divide the current window into half inserting a new window below the
+    current window.
+    """
+
+    layout_key = 'rows'
+    new_cell_indices = [1, 3]


### PR DESCRIPTION
This is a first crack at supporting split-window-right and split-window-below.

It's not perfect because I suck at programming but also because the layout apis are undocumented, and
this was mostly based on looking at how the hardcoded layouts work in the keymap work.

It's unclear to me if the layout engine supports a row spanning multiple columns this code certainly doesn't construct a layout that functions for it.  A split-window-right followed by split-window-below results in a dead group being drawn into the lower right quadrant.
