### PR TITLE
Added EmaxDeleteOtherWindows for C-x 0 Functionality

### DIFF
--- a/base-keymap.json
+++ b/base-keymap.json
@@ -343,6 +343,10 @@
         "command": "emax_other_window"
     },
     {
+        "keys": ["ctrl+x", "1"],
+        "command": "emax_delete_other_windows"
+    },
+    {
         "keys": ["ctrl+x", "2"],
         "command": "emax_split_window_right"
     },

--- a/emax_commands.py
+++ b/emax_commands.py
@@ -806,6 +806,21 @@ class EmaxOtherWindowCommand(WindowCommand):
         )
 
 
+class EmaxDeleteOtherWindows(WindowCommand):
+    """
+    Similar to 'delete-other-windows', i.e. C-x 1.
+
+    Delete all other windows except the active one
+    """
+    def run(self):
+        active = self.window.active_group()
+        layout = self.window.get_layout()
+
+        layout['cells'] = [[0, 0, 1, 1]]
+        layout['rows'] = [0, 1]
+        layout['cols'] = [0, 1]
+        self.window.set_layout(layout)
+
 
 class EmaxSplitWindowRightCommand(WindowCommand):
     """


### PR DESCRIPTION
Hi, 

I'm a new Sublime-Text convert from Emacs, and glad that a plugin like Emax exists to smooth the transition. I was missing a way to close windows created by the emax_split_window\* commands, so I added an analogue to the Emacs command, 'delete-other-windows', and named the command 'emax_delete_other_windows' to suit the project's established naming convention.

I'm issuing a pull request since it may prove useful for someone else as well.

I am also mulling over how to implement 'delete_window' properly, but I still couldn't get some kinks flattened out yet. 

Thanks again for the great plugin!
